### PR TITLE
0.0.67 - clientId + automatically deleting history

### DIFF
--- a/CrashOps.podspec
+++ b/CrashOps.podspec
@@ -16,8 +16,8 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "CrashOps"
-  s.version      = "0.0.66"
-  s.summary      = "CrashOps lets you monitor your app's crashes."
+  s.version      = "0.0.67"
+  s.summary      = "CrashOps helps you monitor your app's stability."
 
   # This description is used to generate tags and improve search results.
   #   * Think: What does it do? Why did you write it? What is the focus?
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   #   * Finally, don't worry about the indent, CocoaPods strips it!
   s.description  = "CrashOps lets you monitor your app's crashes."
 
-  s.homepage     = "https://github.com/CrashOps"
+  s.homepage     = "https://github.com/CrashOps/iOS-SDK"
   # s.screenshots  = "www.example.com/screenshots_1.gif", "www.example.com/screenshots_2.gif"
 
 
@@ -60,7 +60,7 @@ Pod::Spec.new do |s|
 
   # s.swift_version = '5.0'
   s.platform = :ios
-  s.ios.deployment_target = '9.0'
+  s.ios.deployment_target = '8.0'
   s.requires_arc = true
 
   #  When using multiple platforms

--- a/CrashOps.xcodeproj/project.pbxproj
+++ b/CrashOps.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		7538671223BCA5610024EB9F /* CrashOpsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7538671123BCA5610024EB9F /* CrashOpsTests.m */; };
 		7538671423BCA5610024EB9F /* CrashOps.h in Headers */ = {isa = PBXBuildFile; fileRef = 7538670623BCA5610024EB9F /* CrashOps.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7538672C23BCA9330024EB9F /* CrashOps-Bridging-Header.h in Headers */ = {isa = PBXBuildFile; fileRef = 7538672A23BCA9330024EB9F /* CrashOps-Bridging-Header.h */; };
+		75B306CD23FD696E00E7454D /* CrashOpsConfig-info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 75B306CC23FD696E00E7454D /* CrashOpsConfig-info.plist */; };
 		75F04DE523C3826100F65DBF /* CrashOpsController.m in Sources */ = {isa = PBXBuildFile; fileRef = 75F04DE223C3826100F65DBF /* CrashOpsController.m */; };
 		75F04DE623C3826100F65DBF /* CrashOps.m in Sources */ = {isa = PBXBuildFile; fileRef = 75F04DE323C3826100F65DBF /* CrashOps.m */; };
 		75F04DE723C3826100F65DBF /* CrashOpsController.h in Headers */ = {isa = PBXBuildFile; fileRef = 75F04DE423C3826100F65DBF /* CrashOpsController.h */; };
@@ -34,6 +35,7 @@
 		7538671323BCA5610024EB9F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		7538672A23BCA9330024EB9F /* CrashOps-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "CrashOps-Bridging-Header.h"; sourceTree = "<group>"; };
 		7538672B23BCA9330024EB9F /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		75B306CC23FD696E00E7454D /* CrashOpsConfig-info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "CrashOpsConfig-info.plist"; sourceTree = "<group>"; };
 		75F04DE223C3826100F65DBF /* CrashOpsController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CrashOpsController.m; sourceTree = "<group>"; };
 		75F04DE323C3826100F65DBF /* CrashOps.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CrashOps.m; sourceTree = "<group>"; };
 		75F04DE423C3826100F65DBF /* CrashOpsController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CrashOpsController.h; sourceTree = "<group>"; };
@@ -100,10 +102,19 @@
 		7538672923BCA9330024EB9F /* SupportingFiles */ = {
 			isa = PBXGroup;
 			children = (
+				75B306CB23FD696E00E7454D /* example-for-optional-info-plist */,
 				7538672A23BCA9330024EB9F /* CrashOps-Bridging-Header.h */,
 				7538672B23BCA9330024EB9F /* Info.plist */,
 			);
 			path = SupportingFiles;
+			sourceTree = "<group>";
+		};
+		75B306CB23FD696E00E7454D /* example-for-optional-info-plist */ = {
+			isa = PBXGroup;
+			children = (
+				75B306CC23FD696E00E7454D /* CrashOpsConfig-info.plist */,
+			);
+			path = "example-for-optional-info-plist";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -200,6 +211,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				75B306CD23FD696E00E7454D /* CrashOpsConfig-info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/CrashOps/CrashOps.h
+++ b/CrashOps/CrashOps.h
@@ -33,8 +33,13 @@ typedef void(^PreviousReportsHandler)(NSArray *reports);
 @property (nonatomic, assign) NSUncaughtExceptionHandler *appExceptionHandler;
 
 /**
+ *  The client ID received by CrashOps customer services.
+*/
+@property (nonatomic, strong) NSString *clientId;
+
+/**
  *  Determines whether the SDK is enabled or not, it's set to true by default.
- *  This value may also be optionally changed via the 'CrashOps-info.plist' file.
+ *  This value may also be optionally changed via the 'CrashOpsConfig-info.plist' file.
 */
 @property (nonatomic, assign) BOOL isEnabled;
 
@@ -66,12 +71,17 @@ typedef void(^PreviousReportsHandler)(NSArray *reports);
 /**
  *  Causes a crash for testing purposes.
  */
-- (void)crash;
+-(void) crash;
 
 /**
  *  Causes a crash due to exception for testing purposes.
  */
-- (void)throwException;
+-(void) throwException;
+
+/**
+*  Logs non-fatal errors.
+*/
+-(BOOL) logError:(NSDictionary *) errorDetails;
 
 @end
 

--- a/CrashOps/CrashOps.m
+++ b/CrashOps/CrashOps.m
@@ -22,6 +22,7 @@
 
 @implementation CrashOps
 
+@synthesize clientId;
 @synthesize metadata;
 @synthesize isEnabled;
 
@@ -29,6 +30,7 @@
     self = [super init];
     if (self) {
         isEnabled = YES;
+        clientId = @"";
         metadata = [NSMutableDictionary new];
     }
 
@@ -41,6 +43,10 @@
 
 - (void)throwException {
     [NSException raise:@"CrashOps test exception" format: @""];
+}
+
+- (BOOL) logError:(NSDictionary *)errorDetails {
+    return [((CrashOpsController *)([CrashOpsController performSelector: @selector(shared)])) logError: errorDetails];
 }
 
 - (void)crash {
@@ -56,6 +62,19 @@ __strong static CrashOps *_sharedInstance;
     });
     
     return _sharedInstance;
+}
+
+- (void)setClientId:(NSString *)crashOpsClientId {
+    if (![crashOpsClientId length]) {
+        return;
+    }
+
+    if ([crashOpsClientId length] > 100) {
+        return;
+    }
+
+    clientId = crashOpsClientId;
+    ((CrashOpsController *)([CrashOpsController performSelector: @selector(shared)])).clientId = clientId;
 }
 
 - (void)setIsEnabled:(BOOL)isOn {

--- a/CrashOps/CrashOps.m
+++ b/CrashOps/CrashOps.m
@@ -64,6 +64,12 @@ __strong static CrashOps *_sharedInstance;
     return _sharedInstance;
 }
 
+- (void)setPreviousCrashReports:(PreviousReportsHandler) handler {
+    _previousCrashReports = handler;
+
+    [((CrashOpsController *)([CrashOpsController performSelector: @selector(shared)])) onChangedHandler];
+}
+
 - (void)setClientId:(NSString *)crashOpsClientId {
     if (![crashOpsClientId length]) {
         return;

--- a/CrashOps/CrashOpsController.h
+++ b/CrashOps/CrashOpsController.h
@@ -14,8 +14,18 @@
 @interface CrashOpsController: NSObject
 
 /**
+ *  The client ID received by CrashOps customer services.
+*/
+@property (nonatomic, strong) NSString *clientId;
+
+/**
  *  Determines whether the SDK is enabled or not, it's set to true by default.
 */
 @property (nonatomic, assign) BOOL isEnabled;
+
+/**
+*  Logs non-fatal errors.
+*/
+- (BOOL) logError:(NSDictionary *) errorDetails;
 
 @end

--- a/CrashOps/CrashOpsController.h
+++ b/CrashOps/CrashOpsController.h
@@ -28,4 +28,9 @@
 */
 - (BOOL) logError:(NSDictionary *) errorDetails;
 
+/**
+*  Helps to log non-fatal errors.
+*/
+- (void) onChangedHandler;
+
 @end

--- a/CrashOps/CrashOpsController.m
+++ b/CrashOps/CrashOpsController.m
@@ -126,6 +126,10 @@ __strong static CrashOpsController *_shared;
 #endif
 }
 
+- (void)onChangedHandler {
+    [self uploadLogs];
+}
+
 - (void)setClientId:(NSString *)crashOpsClientId {
     if (![crashOpsClientId length]) {
         return;
@@ -305,6 +309,13 @@ __strong static CrashOpsController *_shared;
                         [[NSOperationQueue mainQueue] addOperationWithBlock:^{
                             [CrashOps shared].previousCrashReports(reportDictionaries);
                         }];
+                    } else if ([reportPaths count] > 0) {
+                        // Considered waiting to the first VC to appear (https://spin.atomicobject.com/2014/12/30/method-swizzling-objective-c/) but it's also won't solve all cases by the various developers out there.
+
+                        NSLog(@"Waiting to the host app's handler to be set...");
+//                        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(3 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+//                            [[CrashOpsController shared] uploadLogs]; // Bad solution, we won't use this solution for example...
+//                        });
                     }
                 };
 

--- a/CrashOps/SupportingFiles/example-for-optional-info-plist/CrashOpsConfig-info.plist
+++ b/CrashOps/SupportingFiles/example-for-optional-info-plist/CrashOpsConfig-info.plist
@@ -8,5 +8,7 @@
 	<false/>
 	<key>isDisabledOnDebug</key>
 	<false/>
+	<key>clientId</key>
+	<string></string>
 </dict>
 </plist>


### PR DESCRIPTION
(1) Added `clientId`: only accounts with `clientId` will be able to upload their logs, without it the SDK will be useful only locally.
(2) Now allowing also to log non-fatal errors (TODO: Add an API to expose them).
(3) Reporting to host app only about uploaded errors + deleting each log file that was confirmed to be sent.